### PR TITLE
prevent home button from changing state

### DIFF
--- a/PartyGame/Components/ButtonView.swift
+++ b/PartyGame/Components/ButtonView.swift
@@ -12,6 +12,7 @@ struct ButtonView: View {
     var title: String
     var titleDone: String
     var action: () -> Void
+    var changeToDone: Bool = true
     @State var state = ButtonState.enabled
     enum ButtonState {
         case inactive
@@ -22,7 +23,9 @@ struct ButtonView: View {
         Button {
             if state == .enabled {
                 action()
-                state = .done
+                if (changeToDone) {
+                    state = .done
+                }
             }
             else {
                 action()

--- a/PartyGame/Views/HomeView.swift
+++ b/PartyGame/Views/HomeView.swift
@@ -37,8 +37,7 @@ struct HomeView: View {
                                         .underline(true, color: .lilac)
                                         
                                 }
-                                ButtonView(image: "img-gameController", title: "Start Match", titleDone: "", action: { viewModel.startMultiplayerGame() }
-                                )
+                                ButtonView(image: "img-gameController", title: "Start Match", titleDone: "", action: { viewModel.startMultiplayerGame() }, changeToDone: false)
                             }
                         }
                         .padding()


### PR DESCRIPTION

**Description**

Start Match button state no longer changes after tapping it

**Relates to:**

Hotfix

**Screenshots or Evidence**

<img width="261" height="53" alt="image" src="https://github.com/user-attachments/assets/c4b92f6d-fec1-4e5e-9e82-f9e6cc5fb4ef" />

**How to test**

Single player mode:
Start match, go to Share Play/ Invite Players/ Quick Match, then click the X button to go back to home